### PR TITLE
Fix incorrect 'in' values for currentPage parameters

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1835,7 +1835,7 @@
         "parameters": [
           {
             "name": "currentpage",
-            "in": "path",
+            "in": "query",
             "description": "Page number (starting with 1). Each page has a fixed size of 50 items per page.",
             "required": true,
             "schema": {
@@ -1896,7 +1896,7 @@
         "parameters": [
           {
             "name": "currentpage",
-            "in": "path",
+            "in": "query",
             "description": "Page number (starting with 1). Each page has a fixed size of 50 items per page.",
             "required": true,
             "schema": {
@@ -2204,7 +2204,7 @@
         "parameters": [
           {
             "name": "currentpage",
-            "in": "path",
+            "in": "query",
             "description": "Page number (starting with 1). Each page has a fixed size of 50 entries.",
             "required": true,
             "schema": {
@@ -2304,7 +2304,7 @@
         "parameters": [
           {
             "name": "currentpage",
-            "in": "path",
+            "in": "query",
             "description": "Page number (starting with 1). Each page has a fixed size of 50 items per page.",
             "required": true,
             "schema": {
@@ -2350,7 +2350,7 @@
         "parameters": [
           {
             "name": "currentpage",
-            "in": "path",
+            "in": "query",
             "description": "Page number (starting with 1). Each page has a fixed size of 50 items per page.",
             "required": true,
             "schema": {


### PR DESCRIPTION
Some of the `currentPage` parameters were defined as being in the `path`, when the operation only has one path parameter.  I believe these are `query` parameters based on other definitions of `currentPage` in the spec. This fixes the broken instances and redefines them as being query params. 